### PR TITLE
Update Travis CI cofiguration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
-language: PHP
-
+language: php
 php:
   - 5.4
   - 5.5
   - 5.6
-
-before_script: composer install
-script: php vendor/bin/phpunit --coverage-text
+  - hhvm
+  - nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,5 @@ php:
   - 5.6
   - hhvm
   - nightly
+before_script: composer install
+script: php vendor/bin/phpunit --coverage-text


### PR DESCRIPTION
Fix Travis build error: `The command "phpenv global 5.5" failed and exited with 127 during .`